### PR TITLE
Rename capability removal test

### DIFF
--- a/tests/unit/mlclient/structures/test_permissions.py
+++ b/tests/unit/mlclient/structures/test_permissions.py
@@ -117,7 +117,7 @@ def test_remove_capability():
     assert permission.capabilities() == set()
 
 
-def test_remove_capability_when_does_dot_exist():
+def test_remove_capability_when_does_not_exist():
     permission = Permission("custom_role", {Permission.READ})
     success = permission.remove_capability(Permission.UPDATE)
     assert success is False


### PR DESCRIPTION
## Summary
- rename test_remove_capability_when_does_dot_exist to test_remove_capability_when_does_not_exist

## Testing
- `pytest tests/unit/mlclient/structures/test_permissions.py::test_remove_capability_when_does_not_exist -q -o addopts=` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689de3966b108324a64143334d0ca53f