### PR TITLE
Fix ResourceNotFoundError docstring

### DIFF
--- a/mlclient/exceptions.py
+++ b/mlclient/exceptions.py
@@ -124,7 +124,7 @@ class UnsupportedFileExtensionError(Exception):
 class ResourceNotFoundError(Exception):
     """A custom Exception class for a not found resource.
 
-    Raised while attempting to get a resource that does exist.
+    Raised while attempting to get a resource that does not exist.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary
- fix ResourceNotFoundError docstring to clarify resource absence

## Testing
- `make lint`
- `make unit-test`
- `make integration-test` *(fails: HTTPConnectionPool(host='localhost', port=8002): Max retries exceeded...)*

------
https://chatgpt.com/codex/tasks/task_e_689de3d2009c8324bcc0836d7147d427