### PR TITLE
Handle case-insensitive boolean parsing in response parser

### DIFF
--- a/mlclient/ml_response_parser.py
+++ b/mlclient/ml_response_parser.py
@@ -60,7 +60,7 @@ class MLResponseParser:
         const.HEADER_PRIMITIVE_STRING: lambda data: data,
         const.HEADER_PRIMITIVE_INTEGER: lambda data: int(data),
         const.HEADER_PRIMITIVE_DECIMAL: lambda data: float(data),
-        const.HEADER_PRIMITIVE_BOOLEAN: lambda data: bool(data),
+        const.HEADER_PRIMITIVE_BOOLEAN: lambda data: data.lower() == "true",
         const.HEADER_PRIMITIVE_DATE: lambda data: datetime.strptime(
             data,
             "%Y-%m-%d%z",


### PR DESCRIPTION
## Summary
- parse boolean plain-text values case-insensitively
- use original primitive type headers without lowercasing

## Testing
- `poetry run ruff format mlclient/ml_response_parser.py`
- `poetry run ruff check mlclient/ml_response_parser.py`
- `poetry run pytest tests/unit/mlclient/test_ml_response_parser.py -k plain_text_boolean -q`


------
https://chatgpt.com/codex/tasks/task_e_689de3a8abc0832492bcb696b0f028d3